### PR TITLE
README format updates & minimize telegram alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,25 +15,34 @@ cd diffscript
 
 Install Dependencies:
 
-`pip install -r requirements.txt`
+```
+pip install -r requirements.txt
+```
 
-Install Jsluice
+Install Jsluice:
 
-`go install github.com/BishopFox/jsluice/cmd/jsluice@latest`
+```
+go install github.com/BishopFox/jsluice/cmd/jsluice@latest
+```
 
 ## Usage
 
 Before running the script, ensure you have a `starting_points.txt` file in your script directory with URLs you want to monitor.
+
+Telegram Bot Setup:
+Make sure to set up a [Telegram bot](https://core.telegram.org/bots) and obtain the `bot_token` and `chat_id` to use the messaging feature.
+Once you have the bot token and chat ID, add the following lines to your `.bashrc` or `.zshrc` file:
+
+```
+export TELEGRAM_BOT_TOKEN="your-token-goes-here"
+export TELEGRAM_CHAT_ID="your-chat-id-goes-here"
+```
 
 Run the Script:
 
 ```
 python3 diffscript.py
 ```
-
-Telegram Bot Setup:
-
-Make sure to set up a [Telegram bot](https://core.telegram.org/bots) and obtain the `bot_token` and `chat_id` to use the messaging feature.
 
 Output:
 

--- a/README.md
+++ b/README.md
@@ -1,46 +1,59 @@
-DiffScript
+# DiffScript
 
 DiffScript is a Python script designed for monitoring changes in JavaScript files on specified websites. It compares new and old versions of JS files, identifies new endpoints, and alerts via Telegram messaging for any changes. This script is particularly useful for web developers and security researchers who need to track updates or changes in the JavaScript used by websites.
 
-Installation
+## Installation
 
 To run this script, you will need Python 3 and several dependencies:
 
 Clone the Repository:
-`git clone https://github.com/your-github-username/diffscript.git`
 
-`cd diffscript`
+```
+git clone https://github.com/xssdoctor/diffscript.git
+cd diffscript
+```
 
 Install Dependencies:
-`pip install requests beautifulsoup4 aiohttp`
+
+`pip install -r requirements.txt`
 
 Install Jsluice
-`go install github.com/BishopFox/jsluice/cmd/jsluice@latest`
-Usage
 
-Before running the script, ensure you have a starting_points.txt file in your script directory with URLs you want to monitor.
+`go install github.com/BishopFox/jsluice/cmd/jsluice@latest`
+
+## Usage
+
+Before running the script, ensure you have a `starting_points.txt` file in your script directory with URLs you want to monitor.
 
 Run the Script:
-`python3 diffscript.py`
+
+```
+python3 diffscript.py
+```
 
 Telegram Bot Setup:
-Make sure to set up a Telegram bot and obtain the bot_token and chat_id to use the messaging feature.
-Output:
-The script will create directories for each monitored website, tracking changes in their JavaScript files.
-Features
 
-Monitors specified URLs for JavaScript file changes.
-Compares new and old versions of JS files.
-Identifies new endpoints.
-Sends alerts via Telegram for any updates or changes.
-Credits
+Make sure to set up a [Telegram bot](https://core.telegram.org/bots) and obtain the `bot_token` and `chat_id` to use the messaging feature.
+
+Output:
+
+The script will create directories for each monitored website, tracking changes in their JavaScript files.
+
+## Features
+
+- Monitors specified URLs for JavaScript file changes.
+- Compares new and old versions of JS files.
+- Identifies new endpoints.
+- Sends alerts via Telegram for any updates or changes.
+
+## Credits
 
 This script is adapted from a gist by Greg Sunday, available at this link https://github.com/BishopFox/jsluice. The original concept and portions of the code were developed by Greg Sunday.
 
-Contributing
+## Contributing
 
 Contributions to this project are welcome. Please ensure to follow the existing coding style and add unit tests for any new or changed functionality.
 
-License
+## License
 
 This project is open-source and available under the MIT License.

--- a/diff.py
+++ b/diff.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import requests
 from bs4 import BeautifulSoup
 import re
@@ -9,7 +11,22 @@ from urllib import parse
 from urllib.parse import urljoin
 import os
 
+TELEGRAM_CHAT_ID = ''
+TELEGRAM_BOT_TOKEN = ''
+
 cwd = os.getcwd()
+
+if not os.environ.get('TELEGRAM_BOT_TOKEN'):
+    print('[!] No Telegram bot token found! Consider adding "export TELEGRAM_BOT_TOKEN=\'<your-token>\'" to your .bashrc/.zshrc!')
+    TELEGRAM_BOT_TOKEN = input('Enter one here: ')
+else:
+    TELEGRAM_BOT_TOKEN = os.environ.get('TELEGRAM_BOT_TOKEN')
+
+if not os.environ.get('TELEGRAM_CHAT_ID'):
+    print('[!] No Telegram chat ID found! Consider adding "export TELEGRAM_CHAT_ID=\'<your-chatID>\'" to your .bashrc/.zshrc!')
+    TELEGRAM_CHAT_ID = input('Enter one here: ')
+else:
+    TELEGRAM_CHAT_ID = os.environ.get('TELEGRAM_CHAT_ID')
 
 
 def get_starting_points():
@@ -122,9 +139,7 @@ def load_new_endpoints(working_dir):
 
 def send_telegram_message(message):
     message = parse.quote(message)
-    chat_id = 
-    bot_token = 
-    send_text = f'https://api.telegram.org/bot{bot_token}/sendMessage?chat_id={chat_id}&text={message}'
+    send_text = f'https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/sendMessage?chat_id={TELEGRAM_CHAT_ID}&text={message}'
     resp = requests.get(send_text)
     return resp.json()
 

--- a/diff.py
+++ b/diff.py
@@ -74,7 +74,7 @@ async def download_urls(inputFile, working_dir):
                 with open(os.path.join(working_dir, 'new', basename), 'wb') as outfile:
                     outfile.write(content)
     except:
-        pass
+        return 'download_urls failed to process'
 
 
 async def fetch_js_urls_from_website(html, target_url, working_dir):
@@ -95,7 +95,7 @@ async def fetch_js_urls_from_website(html, target_url, working_dir):
         await asyncio.gather(*tasks)  # Run all download tasks concurrently
         return jsfiles
     except:
-        pass
+        return 'fetch_js_urls_from_website failed to process'
 
 
 def get_new_urls(working_dir):
@@ -116,9 +116,9 @@ def fetch_urls(working_dir, endpoints):
                     if endpoint:
                         endpoints.add(endpoint.strip())
             except Exception as e:
-                pass
+                return f'Exception caught in "fetch_urls": {e}'
     except:
-        pass
+        return 'fetch_urls failed process'
 
 
 def save_endpoints(working_dir, endpoints):
@@ -157,7 +157,7 @@ async def get_js_from_endpoints(endpoints, working_dir):
                     tasks.append(download_urls(endpoint, working_dir))
         await asyncio.gather(*tasks)
     except:
-        pass
+        return 'get_js_from_endpoints failed to process'
 
 
 async def main():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+beautifulsoup4
+aiohttp


### PR DESCRIPTION
The updates are:
- Small formatting changes in README to differentiate headings
- Use environment variables to store the Telegram API key and chatbot key rather than hardcoding as variables
- Move send_telegram_message() function calls out of the for loops in main() to reduce alerts. This should result in 2 alerts max per target: 1 for new URL's, and 1 for new endpoints